### PR TITLE
add scan sub for "samples"

### DIFF
--- a/src/project_utilities/project.ts
+++ b/src/project_utilities/project.ts
@@ -33,26 +33,40 @@ export interface ProjectConfig {
   confFiles: ConfigFiles;
 }
 
+
+async function readAllDirectories(directory: vscode.Uri, projectList: string[]): Promise<void> {
+  try {
+    const files = await vscode.workspace.fs.readDirectory(directory);
+
+    for (const [name, type] of files) {
+      const filePath = vscode.Uri.joinPath(directory, name);
+
+      if (type === vscode.FileType.Directory) {
+        const sampleYamlPath = vscode.Uri.joinPath(filePath, "sample.yaml");
+        try {
+          await vscode.workspace.fs.stat(sampleYamlPath);
+          projectList.push(filePath.fsPath);
+        } catch (error) {
+          await readAllDirectories(filePath, projectList);
+        }
+      }
+    }
+  } catch (error) {
+  }
+}
+
 export async function createNewProjectFromSample(context: vscode.ExtensionContext, wsConfig: WorkspaceConfig) {
   if (!wsConfig.zephyrDir) {
     vscode.window.showErrorMessage("Run `Zephyr IDE: West Update` first.");
     return;
   }
-  let sampleDir = path.join(wsConfig.zephyrDir, "samples/basic");
-  let files = await vscode.workspace.fs.readDirectory(vscode.Uri.file(sampleDir));
-  let projectList: string[] = [];
 
-  while (true) {
-    let file = files.pop();
-    // Stop looping once done.
-    if (file === undefined) {
-      break;
-    }
+  const samplesDir = path.join(wsConfig.zephyrDir, 'samples');
+  const samplesUri = vscode.Uri.file(samplesDir);
 
-    if (file[1] === vscode.FileType.Directory) {
-      projectList.unshift(file[0]);
-    }
-  }
+  const projectList: string[] = [];
+
+  await readAllDirectories(samplesUri, projectList);
 
   const pickOptions: vscode.QuickPickOptions = {
     ignoreFocusOut: true,
@@ -62,15 +76,18 @@ export async function createNewProjectFromSample(context: vscode.ExtensionContex
   let selectedProject = await vscode.window.showQuickPick(projectList, pickOptions);
 
   if (selectedProject) {
-    let projectName = await vscode.window.showInputBox({ title: "Choose Project Name", value: selectedProject });
+    const projectName = path.basename(selectedProject);
 
-    if (projectName) {
-      if (projectName in wsConfig.projects) {
+    const projectDest = await vscode.window.showInputBox({ title: "Choose Project Destination", value: projectName });
+
+    if (projectDest) {
+      if (projectDest in wsConfig.projects) {
         vscode.window.showErrorMessage("A project of that name already exists.");
       }
-      let projectDest = path.join(wsConfig.rootPath, projectName);
-      fs.cpSync(path.join(sampleDir, selectedProject), projectDest, { recursive: true });
-      return projectDest;
+      const destinationPath = path.join(wsConfig.rootPath, projectDest);
+
+      fs.cpSync(selectedProject, destinationPath, { recursive: true });
+      return destinationPath;
     }
   }
 }

--- a/src/project_utilities/project.ts
+++ b/src/project_utilities/project.ts
@@ -34,23 +34,21 @@ export interface ProjectConfig {
 }
 
 
-async function readAllDirectories(directory: vscode.Uri, projectList: string[], rootPath: string): Promise<void> {
+async function readAllDirectories(directory: vscode.Uri, projectList: string[], rootPath: string, relativePath = ''): Promise<void> {
   try {
     const files = await vscode.workspace.fs.readDirectory(directory);
 
     for (const [name, type] of files) {
       const filePath = vscode.Uri.joinPath(directory, name);
+      const fullPath = path.join(relativePath, name); // Keep track of the full path
 
       if (type === vscode.FileType.Directory) {
         const sampleYamlPath = vscode.Uri.joinPath(filePath, "sample.yaml");
         try {
           await vscode.workspace.fs.stat(sampleYamlPath);
-          const relPath = path.relative(rootPath, filePath.fsPath);
-          const relativeParts = relPath.split(path.sep).slice(3); // Exclude the first 3 parts of the path
-          const relativeShortPath = relativeParts.join(path.sep);
-          projectList.push(relativeShortPath);
+          projectList.push(fullPath);
         } catch (error) {
-          await readAllDirectories(filePath, projectList, rootPath);
+          await readAllDirectories(filePath, projectList, rootPath, fullPath);
         }
       }
     }


### PR DESCRIPTION
Add scan sub folders from "samples" to get all sample projects in zephyr

fix for: https://github.com/mylonics/zephyr-ide/issues/7