### PR TITLE
README: Add "Running and Debugging in VS Code" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This extension contributes the following settings:
 
 ## Known Issues
 
-* macOS compatibility is untested. Please make an issue on our gihub page with any incompatibilities found.
+* macOS compatibility is untested. Please make an issue on our github page with any incompatibilities found.
 
 ## Release Notes
 ### 1.0.22
@@ -108,5 +108,9 @@ Fixed not able to remove projects or build.
 ### 1.0.0
 
 Initial release.
+
+## Development and Debugging
+
+See the [Zephyr IDE for VS Code Developer's Guide](developer-guide.md) for development and debugging instructions.
 
 ---

--- a/developer-guide.md
+++ b/developer-guide.md
@@ -1,0 +1,53 @@
+# Zephyr IDE for VS Code Developer's Guide
+
+## Prerequisites
+
+* Git (https://git-scm.com/)
+* Node.js (https://nodejs.org/)
+* Visual Studio Code (https://code.visualstudio.com/)
+
+## Getting Started
+
+### 1. Clone git repository
+
+* Clone this git repository in the current directory of your choice using:
+```
+git clone https://github.com/mylonics/zephyr-ide.git
+```
+
+### 2. Install package dependencies
+
+* Change directories to the `zephyr-ide` directory cloned in Step 1:
+```
+cd zephyr-ide
+```
+
+* Install all the required packages locally to `zephyr-ide/node_modules` using:
+```
+npm install
+```
+
+* (Optional) Install all the required packages globally using:
+```
+npm install -g
+```
+This eliminates the need to reinstall packages after a `git clean` of this directory, or any future `git clone` of this repository.
+
+
+It is recommended that you run `npm install [-g]` again after switching git checkouts, as the required packages may have changed between revisions.
+
+### 3. Open the Extension in VS Code
+
+* Run Visual Studio Code, and close any existing workspaces.
+* Select 'File'->'Add Folder to Workspace...' from the top menu bar
+* Browse and select to the `zephyr-ide` directory that was cloned in Step 1.
+
+### 4. Run and Debug in VS Code
+
+* Use the Explorer view to open the source file `zephyr-ide/src/extension.ts`
+* Run the extension and start debugging:
+    - Select 'Run'->'Start Debugging (F5)' from the top menu bar, or
+    - Use the Run and Debug view, and click the green 'Start Debugging (F5)' button next to the configuration 'Run Extension (zephyr-ide)'
+* A separate VS Code instance will launch to allow you to start debugging the Zephyr IDE extension.
+
+---


### PR DESCRIPTION
Add "Running and Debugging in VS Code" section with full instructions on cloning, installing packages, opening in VS Code, and running and debugging the extension.