### PR TITLE
BuildConfig: Add westBuildArgs and westBuildCMakeArgs

### DIFF
--- a/src/project_utilities/build_selector.ts
+++ b/src/project_utilities/build_selector.ts
@@ -32,6 +32,8 @@ export interface BuildConfig {
   relBoardDir: string;
   relBoardSubDir: string;
   debugOptimization: string;
+  westBuildArgs: string;
+  westBuildCMakeArgs: string;
   runners: RunnerConfigDictionary;
   activeRunner?: string;
   confFiles: ConfigFiles;

--- a/src/zephyr_utilities/build.ts
+++ b/src/zephyr_utilities/build.ts
@@ -83,7 +83,17 @@ export async function build(
   let extraOverlayFiles = project.confFiles.extraOverlay.concat(build.confFiles.extraOverlay);
   extraOverlayFiles = extraOverlayFiles.map(x => (path.join(wsConfig.rootPath, x)));
 
-  let cmd = `west build -b ${build.board} ${path.join(wsConfig.rootPath, project.rel_path)} ${pristine ? "-p" : ""} --build-dir ${path.join(wsConfig.rootPath, project.rel_path, build.name)} -- -DBOARD_ROOT='${path.dirname(path.join(wsConfig.rootPath, build.relBoardDir))}'  `;
+  let extraWestBuildArgs = "";
+  if (build.westBuildArgs !== undefined) {
+    extraWestBuildArgs = build.westBuildArgs;
+  }
+
+  let extraWestBuildCMakeArgs = "";
+  if (build.westBuildCMakeArgs !== undefined) {
+    extraWestBuildCMakeArgs = build.westBuildCMakeArgs;
+  }
+
+  let cmd = `west build -b ${build.board} ${path.join(wsConfig.rootPath, project.rel_path)} ${pristine ? "-p" : ""} --build-dir ${path.join(wsConfig.rootPath, project.rel_path, build.name)} ${extraWestBuildArgs} -- -DBOARD_ROOT='${path.dirname(path.join(wsConfig.rootPath, build.relBoardDir))}' ${extraWestBuildCMakeArgs} `;
   if (primaryConfFiles.length) {
     cmd = cmd + ` -DCONF_FILE='${primaryConfFiles}' `;
   }


### PR DESCRIPTION
These optional configuration items are used as extra argument strings used in creating the 'west build' command string 'west build ... {westBuildArgs} -- ... {westBuildCMakeArgs}'

Resolves #19 