### PR TITLE
fix: Macos Unable to download the xtensa toolchain

### DIFF
--- a/src/setup_utilities/setup_toolchain.ts
+++ b/src/setup_utilities/setup_toolchain.ts
@@ -182,7 +182,7 @@ export async function installSdk(context: vscode.ExtensionContext, globalConfig:
                     };
                     if (getPlatformName() === "macos") {
                         toolchainMinimalDownloadEntry.cmd = toolchainsToInstall.map(targetName => ({
-                            "cmd": "zephyr-sdk-" + toolchainVersion + "/setup.sh -t " + targetName + "-zephyr-" + (targetName === "arm" ? "eabi" : "elf"),
+                            "cmd": "zephyr-sdk-" + toolchainVersion + "/setup.sh -t " + targetName + (targetName.includes("xtensa") ? "_" : "-") + "zephyr-" + (targetName === "arm" ? "eabi" : "elf"),
                             "usepath": true
                         }));
                     }


### PR DESCRIPTION
When selecting the xtensa toolchain,

output:
[SETUP] Installing zephyr-sdk-0.16.8 toolchain...
tar -xvf "/Users/xxx/.zephyr_ide/downloads/zephyr-sdk-0.16.8_macos-aarch64_minimal.tar.xz" -C "/Users/xxx/.zephyr_ide/toolchains"
zephyr-sdk-0.16.8/setup.sh -t xtensa-espressif_esp32s3-zephyr-elf
ERROR: Unknown toolchain 'xtensa-espressif_esp32s3-zephyr-elf'
