### PR TITLE
Fix project name parsing (Issue #105)

### DIFF
--- a/src/project_utilities/project.ts
+++ b/src/project_utilities/project.ts
@@ -136,7 +136,7 @@ export async function createNewProjectFromSample(context: vscode.ExtensionContex
       const selectedProject = path.join(samplesDir, selectedRelativePath.description);
 
       fs.cpSync(selectedProject, destinationPath, { recursive: true });
-      let newProjectName = path.parse(projectDest).name;
+      let newProjectName = path.basename(projectDest);
       if (selectedRelativePath.label !== newProjectName) {
         changeProjectNameInCMakeFile(destinationPath, newProjectName);
       }
@@ -383,7 +383,7 @@ export async function addProject(wsConfig: WorkspaceConfig, context: vscode.Exte
   if (projectPath === undefined) {
     return;
   }
-  let projectName = path.parse(projectPath).name;
+  let projectName = path.basename(projectPath);
   wsConfig.projects[projectName] = {
     rel_path: path.relative(wsConfig.rootPath, projectPath),
     name: projectName,


### PR DESCRIPTION
path.parse(..).name does not properly handle folders with period/dot character in the name as it treats the text after the dot as a file extension and strips it away. Using path.basename resolves this issue while keeping the same behavior on more "standard" path names.
