### PR TITLE
Fix zephyr-ide.build-debug: remove hard coded override of debugConfig.executable

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1072,7 +1072,6 @@ export async function activate(context: vscode.ExtensionContext) {
       );
 
       if (debugConfig && activeProject && activeBuild) {
-        debugConfig.executable = '${command:zephyr-ide.get-active-build-path}/${command:zephyr-ide.get-active-project-name}/zephyr/zephyr.elf';
         // Resolve all ${command:zephyr-ide.*} variables in debugConfig
         async function resolveZephyrCommandsInObject(obj: Record<string, unknown>) {
           for (const key of Object.keys(obj)) {


### PR DESCRIPTION
Removes the hard coded override of the executable path and name in the build and debug command. Fixes the command execution for use cases in that the executable has a different setting in the launch.json.

For example the example repository has set the `executable` set to `${command:zephyr-ide.get-active-build-path}/zephyr/zephyr.elf` (see https://github.com/mylonics/zephyr-ide-samples/blob/main/.vscode/launch.json#L20 ).  
The command `zephyr-ide.build-debug` overrides it with the hard coded value `${command:zephyr-ide.get-active-build-path}/${command:zephyr-ide.get-active-project-name}/zephyr/zephyr.elf` (note the additional `${command:zephyr-ide.get-active-project-name}/`).  
This than leads to a not working debug launch because the elf file is not found.

Other commands e.g. `zephyr-ide.debug` and `zephyr-ide.debug-attach` do not override `executable` and work as expected.