### PR TITLE
Fix workspace-level debug launch: pass config object and resolve inputs

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -187,13 +187,14 @@ function registerWorkspaceSetupCommand(
 }
 
 /**
- * Start a debug session by passing the launch configuration name to VS Code.
- * VS Code resolves variables and settings from launch.json automatically.
+ * Start a debug session for the given mode (debug, attach, or build-debug).
  *
- * When a workspace folder is passed to startDebugging, VS Code only searches
- * that folder's .vscode/launch.json.  Configs defined at workspace level
- * (e.g. in a .code-workspace file) are NOT found that way, so we look up the
- * config first and only pass a folder when the config actually lives there.
+ * Folder-level configs (from .vscode/launch.json) are launched with their
+ * owning folder so VS Code resolves variables and inputs from that file.
+ *
+ * Workspace-level configs (from .code-workspace) are launched without a
+ * folder so VS Code searches workspace-level settings and resolves
+ * ${input:…} variables natively.
  */
 async function startDebugSession(
   context: vscode.ExtensionContext,
@@ -230,12 +231,7 @@ async function startDebugSession(
     }
   }
 
-  // Determine the correct folder to pass to startDebugging.
-  // When a name (string) is passed, VS Code searches only the given folder's
-  // .vscode/launch.json.  If the config lives at workspace level (e.g. in a
-  // .code-workspace file) there is no per-folder launch.json and VS Code
-  // fails with "launch.json does not exist for passed workspace folder".
-  // Look up the config to see where it actually lives.
+  // Pass the folder for folder-level configs, undefined for workspace-level.
   const config = await getLaunchConfigurationByName(wsConfig, debugTarget, debugTargetFolder);
   const resolvedFolderName = config?.workspaceFolder;
   const folder = resolvedFolderName

--- a/src/test/launch-config.test.ts
+++ b/src/test/launch-config.test.ts
@@ -17,7 +17,7 @@ limitations under the License.
 
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { getLaunchConfigurations } from "../utilities/utils";
+import { getLaunchConfigurations, getLaunchConfigurationByName } from "../utilities/utils";
 import { WorkspaceConfig } from "../setup_utilities/types";
 
 suite("Launch Configuration Test Suite", () => {
@@ -32,6 +32,28 @@ suite("Launch Configuration Test Suite", () => {
         };
     }
 
+    // Helper: write configs to a specific scope and clean up after the test.
+    async function withConfigs(
+        scope: vscode.ConfigurationTarget,
+        configs: any[],
+        fn: () => Promise<void>,
+    ) {
+        const folder = vscode.workspace.workspaceFolders?.[0];
+        const launchCfg = scope === vscode.ConfigurationTarget.WorkspaceFolder
+            ? vscode.workspace.getConfiguration("launch", folder?.uri)
+            : vscode.workspace.getConfiguration("launch");
+        await launchCfg.update("configurations", configs, scope);
+        try {
+            await fn();
+        } finally {
+            await launchCfg.update("configurations", undefined, scope);
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Existing tests
+    // ---------------------------------------------------------------
+
     test("folder-level configs appear with workspaceFolder property set", async () => {
         const folder = vscode.workspace.workspaceFolders?.[0];
         if (!folder) { return; } // skip when no workspace folder is available
@@ -40,10 +62,8 @@ suite("Launch Configuration Test Suite", () => {
             { name: "Folder Launch A", type: "cppdbg", request: "launch" },
             { name: "Folder Launch B", type: "cppdbg", request: "attach" },
         ];
-        const launchCfg = vscode.workspace.getConfiguration("launch", folder.uri);
-        await launchCfg.update("configurations", folderConfigs, vscode.ConfigurationTarget.WorkspaceFolder);
 
-        try {
+        await withConfigs(vscode.ConfigurationTarget.WorkspaceFolder, folderConfigs, async () => {
             const result = await getLaunchConfigurations(makeWsConfig());
 
             assert.ok(Array.isArray(result), "result must be an array");
@@ -53,19 +73,15 @@ suite("Launch Configuration Test Suite", () => {
                 assert.strictEqual(found.workspaceFolder, folder.name,
                     `folder config must carry workspaceFolder = "${folder.name}"`);
             }
-        } finally {
-            await launchCfg.update("configurations", undefined, vscode.ConfigurationTarget.WorkspaceFolder);
-        }
+        });
     });
 
     test("configs written via Workspace scope appear in results without duplication", async () => {
         const wsConfigs = [
             { name: "Workspace Launch X", type: "cppdbg", request: "launch" },
         ];
-        const launchCfg = vscode.workspace.getConfiguration("launch");
-        await launchCfg.update("configurations", wsConfigs, vscode.ConfigurationTarget.Workspace);
 
-        try {
+        await withConfigs(vscode.ConfigurationTarget.Workspace, wsConfigs, async () => {
             const result = await getLaunchConfigurations(makeWsConfig());
 
             assert.ok(Array.isArray(result), "result must be an array");
@@ -80,9 +96,7 @@ suite("Launch Configuration Test Suite", () => {
             const matchingEntries = result!.filter((c: any) => c.name === "Workspace Launch X");
             assert.strictEqual(matchingEntries.length, 1,
                 "workspace config must not appear more than once");
-        } finally {
-            await launchCfg.update("configurations", undefined, vscode.ConfigurationTarget.Workspace);
-        }
+        });
     });
 
     test("global-level configs appear in results without duplication", async () => {
@@ -128,5 +142,181 @@ suite("Launch Configuration Test Suite", () => {
         } else {
             assert.strictEqual(result, undefined, "result must be an array or undefined");
         }
+    });
+
+    // ---------------------------------------------------------------
+    // Same-named config across both scopes (deduplication)
+    // ---------------------------------------------------------------
+
+    test("same-named config in both folder and workspace scopes is not duplicated", async () => {
+        const folder = vscode.workspace.workspaceFolders?.[0];
+        if (!folder) { return; }
+
+        const sharedName = "Shared Debug Config";
+        const folderCfg = [{ name: sharedName, type: "cppdbg", request: "launch", program: "folder" }];
+        const wsCfg = [{ name: sharedName, type: "cppdbg", request: "launch", program: "workspace" }];
+
+        const folderLaunch = vscode.workspace.getConfiguration("launch", folder.uri);
+        const wsLaunch = vscode.workspace.getConfiguration("launch");
+        await folderLaunch.update("configurations", folderCfg, vscode.ConfigurationTarget.WorkspaceFolder);
+        await wsLaunch.update("configurations", wsCfg, vscode.ConfigurationTarget.Workspace);
+
+        try {
+            const result = await getLaunchConfigurations(makeWsConfig());
+            assert.ok(Array.isArray(result), "result must be an array");
+
+            const matching = result!.filter((c: any) => c.name === sharedName);
+            assert.strictEqual(matching.length, 1,
+                "same-named config must appear exactly once (deduplicated)");
+        } finally {
+            await folderLaunch.update("configurations", undefined, vscode.ConfigurationTarget.WorkspaceFolder);
+            await wsLaunch.update("configurations", undefined, vscode.ConfigurationTarget.Workspace);
+        }
+    });
+
+    // ---------------------------------------------------------------
+    // Only folder-level configs available (no .code-workspace)
+    // ---------------------------------------------------------------
+
+    test("returns folder configs when only folder scope has configurations", async () => {
+        const folder = vscode.workspace.workspaceFolders?.[0];
+        if (!folder) { return; }
+
+        const configs = [
+            { name: "Folder Only Launch", type: "cortex-debug", request: "launch" },
+        ];
+
+        await withConfigs(vscode.ConfigurationTarget.WorkspaceFolder, configs, async () => {
+            const result = await getLaunchConfigurations(makeWsConfig());
+
+            assert.ok(Array.isArray(result), "result must be an array");
+            const found = result!.find((c: any) => c.name === "Folder Only Launch");
+            assert.ok(found, "folder-only config must be found");
+            assert.strictEqual(found.workspaceFolder, folder.name);
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // Only workspace-level configs available (no launch.json)
+    // ---------------------------------------------------------------
+
+    test("returns workspace configs when only workspace scope has configurations", async () => {
+        const configs = [
+            { name: "Workspace Only Launch", type: "cortex-debug", request: "launch" },
+        ];
+
+        await withConfigs(vscode.ConfigurationTarget.Workspace, configs, async () => {
+            const result = await getLaunchConfigurations(makeWsConfig());
+
+            assert.ok(Array.isArray(result), "result must be an array");
+            const found = result!.find((c: any) => c.name === "Workspace Only Launch");
+            assert.ok(found, "workspace-only config must be found");
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // Both scopes have different configs — union is returned
+    // ---------------------------------------------------------------
+
+    test("configs from both folder and workspace scopes are merged", async () => {
+        const folder = vscode.workspace.workspaceFolders?.[0];
+        if (!folder) { return; }
+
+        // In a single-folder workspace the Workspace and WorkspaceFolder
+        // targets share the same backing file, so we write both configs
+        // into a single scope to avoid one update overwriting the other.
+        const combined = [
+            { name: "Folder Debug", type: "cppdbg", request: "launch" },
+            { name: "Workspace Attach", type: "cppdbg", request: "attach" },
+        ];
+
+        const folderLaunch = vscode.workspace.getConfiguration("launch", folder.uri);
+        await folderLaunch.update("configurations", combined, vscode.ConfigurationTarget.WorkspaceFolder);
+
+        try {
+            const result = await getLaunchConfigurations(makeWsConfig());
+            assert.ok(Array.isArray(result), "result must be an array");
+
+            const folderFound = result!.find((c: any) => c.name === "Folder Debug");
+            const wsFound = result!.find((c: any) => c.name === "Workspace Attach");
+
+            assert.ok(folderFound, "folder config must appear in merged results");
+            assert.ok(wsFound, "workspace config must appear in merged results");
+            assert.strictEqual(result!.length, 2, "exactly two configs expected");
+        } finally {
+            await folderLaunch.update("configurations", undefined, vscode.ConfigurationTarget.WorkspaceFolder);
+        }
+    });
+
+    // ---------------------------------------------------------------
+    // No configs at any scope
+    // ---------------------------------------------------------------
+
+    test("returns undefined when no configurations exist at any scope", async () => {
+        // Clear both scopes to ensure a clean slate.
+        const folder = vscode.workspace.workspaceFolders?.[0];
+        const folderLaunch = folder
+            ? vscode.workspace.getConfiguration("launch", folder.uri) : undefined;
+        const wsLaunch = vscode.workspace.getConfiguration("launch");
+
+        const prevFolder = folderLaunch?.inspect<any[]>("configurations")?.workspaceFolderValue;
+        const prevWs = wsLaunch.inspect<any[]>("configurations")?.workspaceValue;
+
+        if (folderLaunch) {
+            await folderLaunch.update("configurations", undefined, vscode.ConfigurationTarget.WorkspaceFolder);
+        }
+        await wsLaunch.update("configurations", undefined, vscode.ConfigurationTarget.Workspace);
+
+        try {
+            const result = await getLaunchConfigurations(makeWsConfig());
+            // May still pick up global-level configs, so allow array or undefined.
+            if (result !== undefined) {
+                assert.ok(Array.isArray(result), "result must be an array or undefined");
+            }
+        } finally {
+            if (folderLaunch && prevFolder) {
+                await folderLaunch.update("configurations", prevFolder, vscode.ConfigurationTarget.WorkspaceFolder);
+            }
+            if (prevWs) {
+                await wsLaunch.update("configurations", prevWs, vscode.ConfigurationTarget.Workspace);
+            }
+        }
+    });
+
+    // ---------------------------------------------------------------
+    // getLaunchConfigurationByName — lookup by name and folder
+    // ---------------------------------------------------------------
+
+    test("getLaunchConfigurationByName finds config by name", async () => {
+        const folder = vscode.workspace.workspaceFolders?.[0];
+        if (!folder) { return; }
+
+        const configs = [
+            { name: "Named Config A", type: "cortex-debug", request: "launch" },
+            { name: "Named Config B", type: "cppdbg", request: "attach" },
+        ];
+
+        await withConfigs(vscode.ConfigurationTarget.WorkspaceFolder, configs, async () => {
+            const found = await getLaunchConfigurationByName(makeWsConfig(), "Named Config B");
+            assert.ok(found, "config must be found by name");
+            assert.strictEqual(found!.name, "Named Config B");
+        });
+    });
+
+    test("getLaunchConfigurationByName returns undefined for non-existent config", async () => {
+        const found = await getLaunchConfigurationByName(makeWsConfig(), "Does Not Exist");
+        assert.strictEqual(found, undefined, "non-existent config must return undefined");
+    });
+
+    test("getLaunchConfigurationByName finds workspace-scoped config by name", async () => {
+        const configs = [
+            { name: "WS Named Config", type: "cortex-debug", request: "launch" },
+        ];
+
+        await withConfigs(vscode.ConfigurationTarget.Workspace, configs, async () => {
+            const found = await getLaunchConfigurationByName(makeWsConfig(), "WS Named Config");
+            assert.ok(found, "workspace-scoped config must be findable by name");
+            assert.strictEqual(found!.name, "WS Named Config");
+        });
     });
 });


### PR DESCRIPTION
For launch configurations defined in a .code-workspace file, passing the config name (string) to `startDebugging` causes VS Code to search only the folder's `.vscode/launch.json`, failing with "launch.json does not exist for passed workspace folder" even when the file exists with other configs, or if the "launch" configuration is in the .code-workspace.

Pass the config object directly for workspace-level configs so VS Code skips the launch.json lookup. Also fall back to the first workspace folder instead of undefined so VS Code has a scope to resolve ${input:…} variables from the .code-workspace inputs array.

Addresses Issue #407 