### PR TITLE
Fix "launch" and "inputs" defined in .code-workspace file

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -242,7 +242,16 @@ async function startDebugSession(
     ? vscode.workspace.workspaceFolders?.find(f => f.name === resolvedFolderName)
     : undefined;
 
-  const started = await vscode.debug.startDebugging(folder, debugTarget);
+  // When the config lives at workspace level (.code-workspace) rather than in
+  // a folder's launch.json, pass the full config object so VS Code doesn't
+  // attempt a folder-scoped name lookup that would fail.
+  let nameOrConfig: string | vscode.DebugConfiguration = debugTarget;
+  if (config && !resolvedFolderName) {
+    const { workspaceFolder: _wf, ...debugConfig } = config;
+    nameOrConfig = debugConfig as vscode.DebugConfiguration;
+  }
+
+  const started = await vscode.debug.startDebugging(folder, nameOrConfig);
   if (!started) {
     const sessionLabel = mode === 'attach' ? 'attach session' : 'debug session';
     notifyError("Debug", `Failed to start ${sessionLabel}: "${debugTarget}"` +

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,6 +33,7 @@ import {
   executeShellCommandInPythonEnv,
   reloadEnvironmentVariables,
   getLaunchConfigurationByName,
+  resolveConfigInputs,
 } from "./utilities/utils";
 import { notifyError, outputInfo, outputError, outputLine, outputCommandFailure, getDebugOutput, clearDebugOutput } from "./utilities/output";
 import * as project from "./project_utilities/project";
@@ -244,11 +245,17 @@ async function startDebugSession(
 
   // When the config lives at workspace level (.code-workspace) rather than in
   // a folder's launch.json, pass the full config object so VS Code doesn't
-  // attempt a folder-scoped name lookup that would fail.
+  // attempt a folder-scoped name lookup that would fail.  We also need to
+  // resolve ${input:...} variables ourselves since VS Code only does that for
+  // configs it looks up by name from a settings source.
   let nameOrConfig: string | vscode.DebugConfiguration = debugTarget;
   if (config && !resolvedFolderName) {
     const { workspaceFolder: _wf, ...debugConfig } = config;
-    nameOrConfig = debugConfig as vscode.DebugConfiguration;
+    const resolved = await resolveConfigInputs(debugConfig as vscode.DebugConfiguration);
+    if (!resolved) {
+      return; // user cancelled an input prompt or an input was undefined
+    }
+    nameOrConfig = resolved;
   }
 
   const started = await vscode.debug.startDebugging(folder, nameOrConfig);

--- a/src/test/launch-config.test.ts
+++ b/src/test/launch-config.test.ts
@@ -17,7 +17,7 @@ limitations under the License.
 
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { getLaunchConfigurations } from "../utilities/utils";
+import { getLaunchConfigurations, resolveConfigInputs } from "../utilities/utils";
 import { WorkspaceConfig } from "../setup_utilities/types";
 
 suite("Launch Configuration Test Suite", () => {
@@ -127,6 +127,186 @@ suite("Launch Configuration Test Suite", () => {
             }
         } else {
             assert.strictEqual(result, undefined, "result must be an array or undefined");
+        }
+    });
+});
+
+suite("resolveConfigInputs Test Suite", () => {
+
+    test("returns config unchanged when no input references exist", async () => {
+        const config: vscode.DebugConfiguration = {
+            type: "cppdbg",
+            name: "Plain Config",
+            request: "launch",
+            program: "/path/to/app",
+        };
+
+        const result = await resolveConfigInputs(config);
+        assert.deepStrictEqual(result, config);
+    });
+
+    test("resolves command-type input variables", async () => {
+        // Register a temporary command that returns a known value.
+        const cmdId = "zephyr-ide-test.resolveInputCmd";
+        const disposable = vscode.commands.registerCommand(cmdId, (args: any) => {
+            return `resolved-${args}`;
+        });
+
+        const folder = vscode.workspace.workspaceFolders?.[0];
+        if (!folder) {
+            disposable.dispose();
+            return;
+        }
+
+        // Write an input definition to the folder-level launch config.
+        const launchCfg = vscode.workspace.getConfiguration("launch", folder.uri);
+        await launchCfg.update("inputs", [
+            { id: "TestCmd", type: "command", command: cmdId, args: "myarg" },
+        ], vscode.ConfigurationTarget.WorkspaceFolder);
+
+        try {
+            const config: vscode.DebugConfiguration = {
+                type: "cortex-debug",
+                name: "Test Debug",
+                request: "launch",
+                device: "${input:TestCmd}",
+            };
+
+            const result = await resolveConfigInputs(config);
+            assert.ok(result, "result must not be undefined");
+            assert.strictEqual(result!.device, "resolved-myarg");
+            // Other fields remain untouched
+            assert.strictEqual(result!.name, "Test Debug");
+            assert.strictEqual(result!.type, "cortex-debug");
+        } finally {
+            disposable.dispose();
+            await launchCfg.update("inputs", undefined, vscode.ConfigurationTarget.WorkspaceFolder);
+        }
+    });
+
+    test("returns undefined for an undefined input variable", async () => {
+        const config: vscode.DebugConfiguration = {
+            type: "cppdbg",
+            name: "Missing Input",
+            request: "launch",
+            device: "${input:NoSuchInput}",
+        };
+
+        // Clear any inputs that might exist.
+        const folder = vscode.workspace.workspaceFolders?.[0];
+        if (!folder) { return; }
+        const launchCfg = vscode.workspace.getConfiguration("launch", folder.uri);
+        const savedInputs = launchCfg.inspect<any[]>("inputs")?.workspaceFolderValue;
+        await launchCfg.update("inputs", [], vscode.ConfigurationTarget.WorkspaceFolder);
+
+        try {
+            const result = await resolveConfigInputs(config);
+            assert.strictEqual(result, undefined, "must return undefined for missing input");
+        } finally {
+            await launchCfg.update("inputs", savedInputs, vscode.ConfigurationTarget.WorkspaceFolder);
+        }
+    });
+
+    test("resolves multiple input references in a single config", async () => {
+        const cmdId1 = "zephyr-ide-test.multiInput1";
+        const cmdId2 = "zephyr-ide-test.multiInput2";
+        const d1 = vscode.commands.registerCommand(cmdId1, () => "device-A");
+        const d2 = vscode.commands.registerCommand(cmdId2, () => "file-B");
+
+        const folder = vscode.workspace.workspaceFolders?.[0];
+        if (!folder) {
+            d1.dispose(); d2.dispose();
+            return;
+        }
+
+        const launchCfg = vscode.workspace.getConfiguration("launch", folder.uri);
+        await launchCfg.update("inputs", [
+            { id: "DevInput", type: "command", command: cmdId1 },
+            { id: "FileInput", type: "command", command: cmdId2 },
+        ], vscode.ConfigurationTarget.WorkspaceFolder);
+
+        try {
+            const config: vscode.DebugConfiguration = {
+                type: "cortex-debug",
+                name: "Multi",
+                request: "launch",
+                device: "${input:DevInput}",
+                svdFile: "/boards/${input:FileInput}",
+            };
+
+            const result = await resolveConfigInputs(config);
+            assert.ok(result, "result must not be undefined");
+            assert.strictEqual(result!.device, "device-A");
+            assert.strictEqual(result!.svdFile, "/boards/file-B");
+        } finally {
+            d1.dispose(); d2.dispose();
+            await launchCfg.update("inputs", undefined, vscode.ConfigurationTarget.WorkspaceFolder);
+        }
+    });
+
+    test("resolves input references inside nested objects and arrays", async () => {
+        const cmdId = "zephyr-ide-test.nestedInput";
+        const disposable = vscode.commands.registerCommand(cmdId, () => "nestedVal");
+
+        const folder = vscode.workspace.workspaceFolders?.[0];
+        if (!folder) {
+            disposable.dispose();
+            return;
+        }
+
+        const launchCfg = vscode.workspace.getConfiguration("launch", folder.uri);
+        await launchCfg.update("inputs", [
+            { id: "Nested", type: "command", command: cmdId },
+        ], vscode.ConfigurationTarget.WorkspaceFolder);
+
+        try {
+            const config: vscode.DebugConfiguration = {
+                type: "cortex-debug",
+                name: "Nested Test",
+                request: "launch",
+                serverArgs: ["-device", "${input:Nested}", "-speed", "4000"],
+                nested: { inner: "${input:Nested}" },
+            };
+
+            const result = await resolveConfigInputs(config);
+            assert.ok(result, "result must not be undefined");
+            assert.deepStrictEqual(result!.serverArgs, ["-device", "nestedVal", "-speed", "4000"]);
+            assert.strictEqual(result!.nested.inner, "nestedVal");
+        } finally {
+            disposable.dispose();
+            await launchCfg.update("inputs", undefined, vscode.ConfigurationTarget.WorkspaceFolder);
+        }
+    });
+
+    test("input embedded mid-string is substituted inline", async () => {
+        const cmdId = "zephyr-ide-test.midString";
+        const disposable = vscode.commands.registerCommand(cmdId, () => "chip123");
+
+        const folder = vscode.workspace.workspaceFolders?.[0];
+        if (!folder) {
+            disposable.dispose();
+            return;
+        }
+
+        const launchCfg = vscode.workspace.getConfiguration("launch", folder.uri);
+        await launchCfg.update("inputs", [
+            { id: "ChipId", type: "command", command: cmdId },
+        ], vscode.ConfigurationTarget.WorkspaceFolder);
+
+        try {
+            const config: vscode.DebugConfiguration = {
+                type: "cortex-debug",
+                name: "Mid-string",
+                request: "launch",
+                svdFile: "/boards/${input:ChipId}/debug.svd",
+            };
+
+            const result = await resolveConfigInputs(config);
+            assert.ok(result, "result must not be undefined");
+            assert.strictEqual(result!.svdFile, "/boards/chip123/debug.svd");
+        } finally {
+            disposable.dispose();
+            await launchCfg.update("inputs", undefined, vscode.ConfigurationTarget.WorkspaceFolder);
         }
     });
 });

--- a/src/utilities/utils.ts
+++ b/src/utilities/utils.ts
@@ -242,6 +242,131 @@ export async function getLaunchConfigurationByName(wsConfig: WorkspaceConfig, co
 }
 
 /**
+ * Resolve `${input:...}` variable references in a debug configuration.
+ *
+ * VS Code only resolves input variables for configs it looks up by name from a
+ * settings source (launch.json / .code-workspace).  Configs passed as inline
+ * `DebugConfiguration` objects to `startDebugging` bypass that resolution.
+ * This function fills that gap by collecting the `inputs` array from all
+ * launch scopes (folder, workspace, global) and resolving each reference.
+ *
+ * Supports `command`, `promptString`, and `pickString` input types.
+ *
+ * Returns `undefined` if a referenced input is missing or the user cancels a
+ * prompt.
+ */
+export async function resolveConfigInputs(
+  config: vscode.DebugConfiguration
+): Promise<vscode.DebugConfiguration | undefined> {
+  // Collect all ${input:...} ids referenced in the config.
+  const inputRefs = new Set<string>();
+  (function walk(obj: any) {
+    if (typeof obj === 'string') {
+      for (const m of obj.matchAll(/\$\{input:([^}]+)\}/g)) {
+        inputRefs.add(m[1]);
+      }
+    } else if (Array.isArray(obj)) {
+      obj.forEach(walk);
+    } else if (obj && typeof obj === 'object') {
+      Object.values(obj).forEach(walk);
+    }
+  })(config);
+
+  if (inputRefs.size === 0) {
+    return config;
+  }
+
+  // Gather input definitions from folder, workspace, and global scopes.
+  const allInputs: any[] = [];
+  for (const folder of vscode.workspace.workspaceFolders ?? []) {
+    allInputs.push(
+      ...(vscode.workspace.getConfiguration("launch", folder.uri)
+        .inspect<any[]>("inputs")?.workspaceFolderValue ?? [])
+    );
+  }
+  const inspect = vscode.workspace.getConfiguration("launch").inspect<any[]>("inputs");
+  allInputs.push(...(inspect?.workspaceValue ?? []), ...(inspect?.globalValue ?? []));
+
+  const inputById = new Map<string, any>(
+    allInputs.filter(i => i?.id).map(i => [i.id, i])
+  );
+
+  // Resolve each referenced input to a concrete value.
+  const resolved = new Map<string, string>();
+  for (const id of inputRefs) {
+    const def = inputById.get(id);
+    if (!def) {
+      vscode.window.showErrorMessage(
+        `Undefined input variable '${id}' in launch configuration.`
+      );
+      return undefined;
+    }
+
+    let value: string | undefined;
+    switch (def.type) {
+      case 'command':
+        value = await vscode.commands.executeCommand<string>(def.command, def.args);
+        break;
+      case 'promptString':
+        value = await vscode.window.showInputBox({
+          prompt: def.description,
+          value: def.default,
+          password: def.password,
+        });
+        break;
+      case 'pickString': {
+        const rawOptions: any[] = def.options ?? [];
+        const items: vscode.QuickPickItem[] = rawOptions.map((opt: any) =>
+          typeof opt === 'string'
+            ? { label: opt }
+            : { label: opt.label ?? opt.value, description: opt.label ? opt.value : undefined }
+        );
+        const picked = await vscode.window.showQuickPick(items, {
+          placeHolder: def.description,
+        });
+        if (picked) {
+          const match = rawOptions.find((opt: any) =>
+            typeof opt === 'string'
+              ? opt === picked.label
+              : (opt.label ?? opt.value) === picked.label
+          );
+          value = typeof match === 'string' ? match : match?.value;
+        }
+        break;
+      }
+    }
+
+    if (value === undefined) {
+      return undefined; // user cancelled or command returned nothing
+    }
+    resolved.set(id, value);
+  }
+
+  // Substitute resolved values into all string properties.
+  function substitute(obj: any): any {
+    if (typeof obj === 'string') {
+      return obj.replace(
+        /\$\{input:([^}]+)\}/g,
+        (_match, id) => resolved.get(id) ?? _match
+      );
+    }
+    if (Array.isArray(obj)) {
+      return obj.map(substitute);
+    }
+    if (obj && typeof obj === 'object') {
+      const out: any = {};
+      for (const [k, v] of Object.entries(obj)) {
+        out[k] = substitute(v);
+      }
+      return out;
+    }
+    return obj;
+  }
+
+  return substitute(config);
+}
+
+/**
  * Format a launch target name for display.  In multi-root workspaces the
  * originating workspace folder is appended so the user can distinguish
  * identically-named configurations from different folders.


### PR DESCRIPTION
Switch the Configuration loader to use ConfigObjects instead of filename strings.
This then required a manual InputsResolver function so that Inputs could be resolved in the Config object.
Also, added tests for the new InputResolver.
Addresses Issue #407 